### PR TITLE
Fix the horde manager overlay with non-1 GUI scale

### DIFF
--- a/1.5/Source/Events/HordeModeManager.cs
+++ b/1.5/Source/Events/HordeModeManager.cs
@@ -131,7 +131,7 @@ namespace VFEInsectoids
                 InitializeWaveActivities();
             }
 
-            float screenWidth = Screen.width;
+            float screenWidth = UI.screenWidth;
             float iconWidthWithSpacing = waveIconSize.x + 5f;
             int totalIcons = waveActivities.Count;
             float totalIconsWidth = totalIcons * iconWidthWithSpacing;


### PR DESCRIPTION
With GUI scale above 1 the overlay will be drawn off-screen. GUI scale below 1 (which requires additional mods or manually editing setting files) would likely result in the overlay being drawn away from the edge, moved towards the left side of the screen.

The fix is to use `UI.screenWidth` for screen width, as it's the value RimWorld calculates based on the current GUI scale.