### PR TITLE
Fixing royal jellyfloor to have jellyfloor affordance.

### DIFF
--- a/1.5/Defs/TerrainDefs/Terrain_Floors.xml
+++ b/1.5/Defs/TerrainDefs/Terrain_Floors.xml
@@ -107,6 +107,7 @@
     <affordances>
       <li>Light</li>
 	  <li>VFEI2_Creep</li>
+    <li>VFEI2_JellyFloor</li>
       <li>Medium</li>
       <li>Heavy</li>
     </affordances>


### PR DESCRIPTION
When playing, my royal jellyspreader was destroyed, and I couldn't rebuild it on the same spot, since the royal jellyspreader had converted it to royal jelly. I assume this is an oversight, since the royal jellyspreader is the only "Jellyfloor only" affordance building in the mod. My assumption is that royal jellyfloor should be treated in all ways as jellyfloor, but better, and the royal jellyspreader should be buildable on it.